### PR TITLE
ap generate: optional presubmit skip for docs-only pull requests

### DIFF
--- a/ap/README.md
+++ b/ap/README.md
@@ -62,7 +62,22 @@ General configuration for `ap` itself.
 Example `.ap/ap.yaml`:
 ```yaml
 version: "v0.1.0"
+presubmits:
+  skipIfOnlyChanged:
+  - docs/*
+  - README.md
 ```
+
+`presubmits.skipIfOnlyChanged` is an optional list of bash case globs
+matched against each repo-relative changed path (`*` also matches `/`).
+When every file changed by a pull request matches one of the patterns,
+the generated presubmit scripts exit early but successfully, so
+required status checks stay green without paying for a full run (a
+`paths:` filter on the workflow would instead leave required checks
+pending forever). The guard fails open — shallow history or a
+non-merge HEAD falls through to a full run — and push / merge_group
+events always run everything, so a merge queue remains a complete
+gate. Only list paths no presubmit output depends on.
 
 ## Usage
 

--- a/ap/pkg/generate/generate.go
+++ b/ap/pkg/generate/generate.go
@@ -208,6 +208,11 @@ func runGenerateVerifierGenerator(_ context.Context, repoRoot string) error {
 		return fmt.Errorf("failed to generate header: %w", err)
 	}
 
+	skipGuard, err := presubmitSkipGuardFromConfig(repoRoot)
+	if err != nil {
+		return err
+	}
+
 	content := fmt.Sprintf(`#!/bin/bash
 
 %s
@@ -217,7 +222,7 @@ set -o pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
-
+%s
 # Run generation
 %s generate //...
 
@@ -228,7 +233,7 @@ if [[ -n $(git status --porcelain) ]]; then
   git status
   exit 1
 fi
-`, headerContent, apCmd, apCmd)
+`, headerContent, skipGuard, apCmd, apCmd)
 	if err := writeFileIfChanged(targetFile, []byte(content), 0755); err != nil {
 		return fmt.Errorf("failed to write %s: %w", targetFile, err)
 	}
@@ -260,6 +265,11 @@ func runApTestGenerator(_ context.Context, repoRoot string) error {
 		return fmt.Errorf("failed to generate header: %w", err)
 	}
 
+	skipGuard, err := presubmitSkipGuardFromConfig(repoRoot)
+	if err != nil {
+		return err
+	}
+
 	content := fmt.Sprintf(`#!/bin/bash
 
 %s
@@ -269,10 +279,10 @@ set -o pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
-
+%s
 # Run tests
 %s test //...
-`, headerContent, apCmd)
+`, headerContent, skipGuard, apCmd)
 	if err := writeFileIfChanged(targetFile, []byte(content), 0755); err != nil {
 		return fmt.Errorf("failed to write %s: %w", targetFile, err)
 	}
@@ -304,6 +314,11 @@ func runApLintGenerator(_ context.Context, repoRoot string) error {
 		return fmt.Errorf("failed to generate header: %w", err)
 	}
 
+	skipGuard, err := presubmitSkipGuardFromConfig(repoRoot)
+	if err != nil {
+		return err
+	}
+
 	content := fmt.Sprintf(`#!/bin/bash
 
 %s
@@ -313,10 +328,10 @@ set -o pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
-
+%s
 # Run linting
 %s lint //...
-`, headerContent, apCmd)
+`, headerContent, skipGuard, apCmd)
 	if err := writeFileIfChanged(targetFile, []byte(content), 0755); err != nil {
 		return fmt.Errorf("failed to write %s: %w", targetFile, err)
 	}
@@ -376,6 +391,11 @@ func runApBuildGenerator(_ context.Context, repoRoot string, scopes []*tasks.APS
 		return fmt.Errorf("failed to generate header: %w", err)
 	}
 
+	skipGuard, err := presubmitSkipGuardFromConfig(repoRoot)
+	if err != nil {
+		return err
+	}
+
 	content := fmt.Sprintf(`#!/bin/bash
 
 %s
@@ -385,10 +405,10 @@ set -o pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
-
+%s
 # Run build
 %s build //...
-`, headerContent, apCmd)
+`, headerContent, skipGuard, apCmd)
 	if err := writeFileIfChanged(targetFile, []byte(content), 0755); err != nil {
 		return fmt.Errorf("failed to write %s: %w", targetFile, err)
 	}
@@ -449,6 +469,11 @@ func runApE2eGenerator(_ context.Context, repoRoot string, scopes []*tasks.APSco
 			return fmt.Errorf("failed to generate header: %w", err)
 		}
 
+		skipGuard, err := presubmitSkipGuardFromConfig(repoRoot)
+		if err != nil {
+			return err
+		}
+
 		content := fmt.Sprintf(`#!/bin/bash
 
 %s
@@ -458,10 +483,10 @@ set -o pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
-
+%s
 # Run e2e tests
 %s e2e %s
-`, headerContent, apCmd, relApRoot)
+`, headerContent, skipGuard, apCmd, relApRoot)
 		if err := writeFileIfChanged(targetFile, []byte(content), 0755); err != nil {
 			return fmt.Errorf("failed to write %s: %w", targetFile, err)
 		}
@@ -635,6 +660,117 @@ func GetApCommand(repoRoot, apRoot string) (string, error) {
 	}
 
 	return defaultCmd, nil
+}
+
+// loadPresubmitSkipPatterns returns presubmits.skipIfOnlyChanged from
+// .ap/ap.yaml, or nil when the file or the setting is absent.
+func loadPresubmitSkipPatterns(repoRoot string) ([]string, error) {
+	configPath := filepath.Join(repoRoot, ".ap", "ap.yaml")
+	data, err := os.ReadFile(configPath)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", configPath, err)
+	}
+
+	var config struct {
+		Presubmits struct {
+			SkipIfOnlyChanged []string `json:"skipIfOnlyChanged"`
+		} `json:"presubmits"`
+	}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", configPath, err)
+	}
+
+	patterns := config.Presubmits.SkipIfOnlyChanged
+	for _, p := range patterns {
+		if !presubmitSkipPatternOK(p) {
+			return nil, fmt.Errorf("%s: presubmits.skipIfOnlyChanged pattern %q: only letters, digits, and / . _ - * ? ! [ ] are allowed", configPath, p)
+		}
+	}
+	return patterns, nil
+}
+
+// presubmitSkipPatternOK reports whether a skipIfOnlyChanged pattern
+// is safe to splice into the generated bash `case` statement.
+func presubmitSkipPatternOK(p string) bool {
+	if p == "" {
+		return false
+	}
+	for _, r := range p {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case strings.ContainsRune("/._-*?![]", r):
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// presubmitSkipGuardFromConfig renders the early-exit block spliced
+// into every generated presubmit script, or "" when the repo doesn't
+// configure presubmits.skipIfOnlyChanged (keeping generated output
+// byte-identical for repos that don't opt in).
+func presubmitSkipGuardFromConfig(repoRoot string) (string, error) {
+	patterns, err := loadPresubmitSkipPatterns(repoRoot)
+	if err != nil {
+		return "", err
+	}
+	return presubmitSkipGuard(patterns), nil
+}
+
+// presubmitSkipGuard returns a bash fragment that exits the presubmit
+// early (and successfully) when a pull request only changes files
+// matching the given case globs. Exiting green — instead of a `paths:`
+// filter on the generated workflow — keeps required status checks
+// satisfied; a workflow skipped by `paths:` leaves them pending
+// forever. The guard fails open: shallow history, a non-merge HEAD,
+// or an empty diff all fall through to a full run, and push /
+// merge_group events are never skipped, so the merge queue remains a
+// complete gate.
+func presubmitSkipGuard(patterns []string) string {
+	if len(patterns) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(`
+# Pull requests whose changed files all match the patterns in
+# .ap/ap.yaml (presubmits.skipIfOnlyChanged) don't need this
+# presubmit; exit early but successfully so required status checks
+# stay green. The patterns are bash case globs matched against each
+# repo-relative path (* also matches /). Anything uncertain — shallow
+# history, a non-merge HEAD, an empty diff — falls through to a full
+# run, and push / merge_group events always run everything.
+if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" && -n "${GITHUB_SHA:-}" ]]; then
+  if ! git rev-parse --verify --quiet "${GITHUB_SHA}^1" >/dev/null; then
+    # actions/checkout does a depth-1 clone of the PR merge commit;
+    # deepen it so the parents are available for diffing.
+    git fetch --quiet --depth=2 origin "${GITHUB_SHA}" >/dev/null 2>&1 || true
+  fi
+  # Diffing the merge commit against its first parent yields exactly
+  # the PR's changes; without a merge commit we can't tell, so run.
+  if git rev-parse --verify --quiet "${GITHUB_SHA}^2" >/dev/null; then
+    ap_changed="$(git diff --name-only "${GITHUB_SHA}^1" "${GITHUB_SHA}")" || ap_changed=""
+    if [[ -n "${ap_changed}" ]]; then
+      ap_skip="true"
+      while IFS= read -r ap_file; do
+        case "${ap_file}" in
+        %s) ;;
+        *)
+          ap_skip="false"
+          break
+          ;;
+        esac
+      done <<<"${ap_changed}"
+      if [[ "${ap_skip}" == "true" ]]; then
+        echo "All changed files match presubmits.skipIfOnlyChanged; skipping $(basename "$0")."
+        exit 0
+      fi
+    fi
+  fi
+fi
+`, strings.Join(patterns, "|"))
 }
 
 func writeFileIfChanged(path string, content []byte, perm os.FileMode) error {

--- a/ap/pkg/generate/generate_test.go
+++ b/ap/pkg/generate/generate_test.go
@@ -80,6 +80,147 @@ func TestGetApCommand(t *testing.T) {
 	}
 }
 
+func TestLoadPresubmitSkipPatterns(t *testing.T) {
+	cases := []struct {
+		name    string
+		apYAML  string // empty = no .ap/ap.yaml
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "no config file",
+			want: nil,
+		},
+		{
+			name:   "config without presubmits",
+			apYAML: `version: latest`,
+			want:   nil,
+		},
+		{
+			name: "patterns",
+			apYAML: `version: latest
+presubmits:
+  skipIfOnlyChanged:
+  - docs/*
+  - README.md
+  - "*.md"`,
+			want: []string{"docs/*", "README.md", "*.md"},
+		},
+		{
+			name: "rejects shell metacharacters",
+			apYAML: `presubmits:
+  skipIfOnlyChanged:
+  - "docs/*;rm -rf"`,
+			wantErr: true,
+		},
+		{
+			name: "rejects empty pattern",
+			apYAML: `presubmits:
+  skipIfOnlyChanged:
+  - ""`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			if tc.apYAML != "" {
+				if err := os.MkdirAll(filepath.Join(root, ".ap"), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(root, ".ap", "ap.yaml"), []byte(tc.apYAML+"\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := loadPresubmitSkipPatterns(root)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("loadPresubmitSkipPatterns = %v, want error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("loadPresubmitSkipPatterns: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("loadPresubmitSkipPatterns = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("pattern[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestPresubmitScriptsWithoutSkipConfig guards byte-stability for
+// repos that don't opt in: without presubmits.skipIfOnlyChanged the
+// generated scripts must not contain the guard, so existing consumer
+// repos see no diff from ap-verify-generate.
+// writeTestHeadersConfig writes the minimal .ap/headers.yaml the
+// script generators need to render file headers.
+func writeTestHeadersConfig(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, ".ap"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	headersYAML := "license: apache-2.0\ncopyrightHolder: Google LLC\n"
+	if err := os.WriteFile(filepath.Join(root, ".ap", "headers.yaml"), []byte(headersYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPresubmitScriptsWithoutSkipConfig(t *testing.T) {
+	root := t.TempDir()
+	writeTestHeadersConfig(t, root)
+	if err := runApTestGenerator(t.Context(), root); err != nil {
+		t.Fatalf("runApTestGenerator: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(root, "dev", "ci", "presubmits", "ap-test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "skipIfOnlyChanged") {
+		t.Errorf("guard emitted without config:\n%s", b)
+	}
+	if !strings.Contains(string(b), "cd \"${REPO_ROOT}\"\n\n# Run tests") {
+		t.Errorf("expected original spacing preserved; got:\n%s", b)
+	}
+}
+
+func TestPresubmitScriptsWithSkipConfig(t *testing.T) {
+	root := t.TempDir()
+	writeTestHeadersConfig(t, root)
+	apYAML := `presubmits:
+  skipIfOnlyChanged:
+  - docs/*
+  - README.md
+`
+	if err := os.WriteFile(filepath.Join(root, ".ap", "ap.yaml"), []byte(apYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runApTestGenerator(t.Context(), root); err != nil {
+		t.Fatalf("runApTestGenerator: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(root, "dev", "ci", "presubmits", "ap-test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(b)
+	if !strings.Contains(script, "docs/*|README.md) ;;") {
+		t.Errorf("expected case patterns in guard; got:\n%s", script)
+	}
+	if !strings.Contains(script, `if [[ "${GITHUB_EVENT_NAME:-}" == "pull_request"`) {
+		t.Errorf("expected pull_request gate in guard; got:\n%s", script)
+	}
+	// The guard must precede the actual work so the skip avoids it.
+	if guardIdx, runIdx := strings.Index(script, "skipIfOnlyChanged"), strings.Index(script, "# Run tests"); guardIdx < 0 || runIdx < 0 || guardIdx > runIdx {
+		t.Errorf("guard not placed before the test invocation:\n%s", script)
+	}
+}
+
 // TestPinnedActionRefs guards the org hash-pin policy: generated
 // workflows must reference actions by full commit SHA, never by a
 // mutable tag.


### PR DESCRIPTION
## Problem

Repos consuming ap's generated CI pay the full presubmit suite (build, lint, test, e2e) on every pull request, including changes the suite doesn't exercise at all. Concrete example from gke-labs/in-cluster-observability: a dependabot bump of the `sharp` npm package under `docs/site/` ran two e2e cluster jobs plus the full Go build/lint/test, and then a flaky Go test blocked the docs-only bump ([run](https://github.com/gke-labs/in-cluster-observability/actions/runs/30536903702)).

A `paths:`/`paths-ignore:` filter on the generated workflow doesn't work here: when the workflow is skipped, required status checks stay pending forever and block the merge. And consumers can't patch the scripts or workflow by hand because `ap-verify-generate` requires byte-equality with fresh generator output.

## Change

Adds an opt-in `presubmits.skipIfOnlyChanged` list to `.ap/ap.yaml`:

```yaml
version: v0.1.0
presubmits:
  skipIfOnlyChanged:
  - docs/*
  - README.md
```

When set, every generated presubmit script gains a guard that, on `pull_request` events only, diffs the PR merge commit against its first parent and exits early **but successfully** when all changed files match one of the configured bash case globs — so required checks stay green without paying for the run.

Safety properties:
- **Fails open**: shallow history (the guard deepens the depth-1 checkout by one), a non-merge HEAD, or an empty diff all fall through to a full run.
- **push / merge_group are never skipped**, so a merge queue remains a complete gate.
- Patterns are validated against a conservative character set before being spliced into the generated bash.
- Repos that don't set the option get **byte-identical output** — no `ap-verify-generate` churn for existing consumers (covered by a test).

## Testing

- Unit tests for config parsing/validation and generated-script content (with and without the option).
- End-to-end against in-cluster-observability with the patched generator: docs-only PR merge commit → script exits 0 with a skip message before invoking ap; mixed PR and push events → full run; regeneration without the option → zero diff.